### PR TITLE
fix: reset ui settings during editor component initialisation

### DIFF
--- a/src/app/core/state/ui.state.ts
+++ b/src/app/core/state/ui.state.ts
@@ -77,20 +77,26 @@ export class ToggleCodeEditor {
   constructor(public value: boolean) {}
 }
 
+export class ResetUiSettings {
+  static readonly type = '[UiSettings] Reset UI Settings';
+}
+
+const DEFAULT_UI_STATE = {
+  wireframe: true,
+  preview: true,
+  availablePages: [],
+  currentLayer: null,
+  previousLayer: null,
+  currentFile: null,
+  currentPage: null,
+  zoomLevel: 1,
+  is3dView: false,
+  isCodeEditor: false
+};
+
 @State<UiSettings>({
   name: 'ui',
-  defaults: {
-    wireframe: true,
-    preview: true,
-    availablePages: [],
-    currentLayer: null,
-    previousLayer: null,
-    currentFile: null,
-    currentPage: null,
-    zoomLevel: 1,
-    is3dView: false,
-    isCodeEditor: false
-  }
+  defaults: DEFAULT_UI_STATE
 })
 export class UiState {
   constructor(private snackBar: MatSnackBar) {}
@@ -274,5 +280,9 @@ export class UiState {
     patchState({
       isCodeEditor: action.value
     });
+  }
+  @Action(ResetUiSettings)
+  resetUiSettings({ patchState }: StateContext<UiSettings>, action: ResetUiSettings) {
+    patchState(DEFAULT_UI_STATE);
   }
 }

--- a/src/app/editor/editor.component.ts
+++ b/src/app/editor/editor.component.ts
@@ -11,7 +11,8 @@ import {
   Toggle3D,
   ToggleWireframe,
   TogglePreview,
-  ToggleCodeEditor
+  ToggleCodeEditor,
+  ResetUiSettings
 } from 'src/app/core/state';
 import { SketchContainerComponent } from './viewer/lib/sketch-container.component';
 
@@ -53,6 +54,8 @@ export class EditorComponent implements OnInit {
     this.colors = {
       background: 'transparent'
     };
+
+    this.store.dispatch(new ResetUiSettings());
 
     this.store.select(UiState.availablePages).subscribe(availablePages => {
       this.sketchPages = availablePages;


### PR DESCRIPTION
at this moment when user uploads some file, go to start page
and back to editor, preview is not available but tree view still has
layers from previous file.