### PR TITLE
fix(editor): convert RegExp that use dotAll flag to old syntax

### DIFF
--- a/src/app/editor/layer-settings/settings-layer-colors/settings-layer-colors.component.ts
+++ b/src/app/editor/layer-settings/settings-layer-colors/settings-layer-colors.component.ts
@@ -110,7 +110,7 @@ export class SettingsLayerColorsComponent implements OnInit {
   computeBackgourndGradient() {
     if (this.componentStyle) {
       if (this.isBackgroundGradient()) {
-        this.gradients = this.componentStyle['background-color'].match(/(rgba[\d,()% ]+)/gsu).map(match => {
+        this.gradients = this.componentStyle['background-color'].match(/(rgba[ %\(\),0-9]+)/gu).map(match => {
           const m = match.split(' ');
           return {
             backgroundColor: m[0],

--- a/src/app/editor/viewer/lib/parsers/bplist-parser.service.ts
+++ b/src/app/editor/viewer/lib/parsers/bplist-parser.service.ts
@@ -597,7 +597,7 @@ export class BinaryPropertyListParserService {
   }
 
   private isBase64(value: string) {
-    return /^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)$/su.test(value);
+    return /^([\+\/-9A-Za-z]{4})*([\+\/-9A-Za-z]{4}|[\+\/-9A-Za-z]{3}=|[\+\/-9A-Za-z]{2}==)$/u.test(value);
   }
 }
 


### PR DESCRIPTION
Fix #19 

The problem is in the unsupported dotAll aka `s` RegExp flag in Firefox. The flag is in the [stage-4 of Ecma-262 proposals stage](https://github.com/tc39/proposal-regexp-dotall-flag). RegExp-s that used such flag were converted to ES5 equivalent using [converter](https://mothereff.in/regexpu#input=const+regex+%3D+/foo.bar/s%3B%0Aconsole.log%28%0A++regex.test%28%27foo%5Cnbar%27%29%0A%29%3B%0A//+%E2%86%92+true&dotAllFlag=1).