### PR TITLE
style(home): avoid horizontal scroll on mobile devices

### DIFF
--- a/src/app/home/landing/landing.component.css
+++ b/src/app/home/landing/landing.component.css
@@ -13,7 +13,7 @@ header {
 header h1 {
   text-align: center;
   font-weight: 100;
-  font-size: 3em;
+  font-size: 2.5em;
   padding: 22px 0 0;
 }
 
@@ -67,7 +67,7 @@ header img {
   padding: 10px 30px;
   text-decoration: none;
   border-radius: 50px;
-  font-size: 2em;
+  font-size: 1.5em;
   background: linear-gradient(217deg, #ff6c5f, #ff4f81 70.71%),
     linear-gradient(127deg, #3369e7, #b84592 70.71%),
     linear-gradient(336deg, #ff4f81, #ffc168 70.71%);
@@ -113,6 +113,11 @@ footer i {
   text-align: center;
 }
 
+.bg img {
+  width: 600px;
+  max-width: 100%;
+}
+
 .bg p {
   padding: 0px 60px;
 }
@@ -120,8 +125,8 @@ footer i {
 .bg-2:before {
   content: '';
   display: block;
-  width: 200px;
-  height: 200px;
+  width: 150px;
+  height: 150px;
   position: absolute;
   background: url(/assets/xlayers-bg-2.png) -270px -80px/680px no-repeat;
   border-radius: 50%;
@@ -133,8 +138,8 @@ footer i {
 .bg-3:before {
   content: '';
   display: block;
-  width: 200px;
-  height: 200px;
+  width: 150px;
+  height: 150px;
   position: absolute;
   background: url(/assets/xlayers-bg-3.png) -60px -80px/680px no-repeat;
   border-radius: 50%;
@@ -144,8 +149,22 @@ footer i {
 }
 
 @media (min-width: 500px) {
+  header h1 {
+    font-size: 3em;
+  }
+
+  .try-it a {
+    font-size: 2em;
+  }
+
+  .bg p {
+    font-size: 24px;
+  }
+
   .bg-2:before,
   .bg-3:before {
+    width: 200px;
+    height: 200px;
     margin-top: -106px;
   }
 }

--- a/src/app/home/landing/landing.component.html
+++ b/src/app/home/landing/landing.component.html
@@ -21,22 +21,22 @@
 </section>
 
 <section class="bg bg-0">
-  <img width="600" src="/assets/xlayers-bg-0.png" />
+  <img src="/assets/xlayers-bg-0.png" />
   <p class="mat-headline">Designers will usually use the SketchApp<sup>1</sup> app to create beautiful UI components...</p>
 </section>
 
 <section class="bg bg-4">
-  <img width="600" src="/assets/xlayers-bg-4.png" />
+  <img src="/assets/xlayers-bg-4.png" />
   <p class="mat-headline">Now, Designers can simply drag and drop the SketchApp project file (*.sketch) containing the UI component into xLayers to preview their creation directly inside the browser.</p>
 </section>
 
 <section class="bg bg-2">
-  <img width="600" src="/assets/xlayers-bg-2.png" />
+  <img src="/assets/xlayers-bg-2.png" />
   <p class="mat-headline">xLayers even has a 3D viewing mode allowing both Designers and Developers to preview all the layers that compose the UI component, and inspect their size, position and color properties.</p>
 </section>
 
 <section class="bg bg-3">
-  <img width="600" src="/assets/xlayers-bg-3-ng.png" />
+  <img src="/assets/xlayers-bg-3-ng.png" />
   <p class="mat-headline">Developers would usually use xLayers to export the UI component made with the SketchApp app as an Angular component and import it into an existing Angular application.</p>
 </section>
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -8,7 +8,7 @@ html {
   min-height: 100%;
   position: relative;
   font-family: 'Roboto', sans-serif;
-  min-width: 390px;
+  min-width: 320px;
 }
 
 .bg-pattern {


### PR DESCRIPTION
The content overflows horizontally on mobile devices due to fixed width of images. This is fixed using a max-width. Also the font-size tends to be too big so it is reduced for small viewports