### PR TITLE
fix: lint folder exception

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -1,4 +1,10 @@
 {
+  "linterOptions": {
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+  },
   "rulesDirectory": [
     "node_modules/codelyzer"
   ],


### PR DESCRIPTION
`VS Code`'s auto-linter ran over all folders and my MacAirplane was ready to take off.