### PR TITLE
chore: improved legacy sketch parser

### DIFF
--- a/src/app/editor/viewer/lib/parsers/sketch-style-parser.service.spec.ts
+++ b/src/app/editor/viewer/lib/parsers/sketch-style-parser.service.spec.ts
@@ -36,13 +36,9 @@ describe('SketchStyleParserService', () => {
           }
         }
       } as any;
-      const root = {};
-      sketchStyleParserService.parseTextFont(obj, root);
-      expect(root).toEqual({
-        css: {
-          'font-family': 'Roboto-Medium, \'Roboto\', sans-serif',
-          'font-size': '14px',
-        },
+      expect(sketchStyleParserService.transformTextFont(obj)).toEqual({
+        'font-family': '\'Roboto-Medium\', \'Roboto\', \'sans-serif\'',
+        'font-size': '14px',
       });
     });
 
@@ -57,9 +53,7 @@ describe('SketchStyleParserService', () => {
           }
         }
       } as SketchMSLayer;
-      const root = {};
-      sketchStyleParserService.parseTextFont(obj, root);
-      expect(root).toEqual({});
+      expect(sketchStyleParserService.transformTextFont(obj)).toEqual({});
     });
 
     it('should parse color', () => {
@@ -77,12 +71,8 @@ describe('SketchStyleParserService', () => {
           }
         }
       } as SketchMSLayer;
-      const root = {};
-      sketchStyleParserService.parseTextColor(obj, root);
-      expect(root).toEqual({
-        css: {
-          color: 'rgba(255,82,166,0.4)'
-        },
+      expect(sketchStyleParserService.transformTextColor(obj)).toEqual({
+        color: 'rgba(255,82,166,0.4)'
       });
     });
 
@@ -94,12 +84,8 @@ describe('SketchStyleParserService', () => {
           }
         }
       } as SketchMSLayer;
-      const root = {};
-      sketchStyleParserService.parseTextColor(obj, root);
-      expect(root).toEqual({
-        css: {
-          color: 'black'
-        },
+      expect(sketchStyleParserService.transformTextColor(obj)).toEqual({
+        color: 'black'
       });
     });
   });
@@ -161,39 +147,29 @@ describe('SketchStyleParserService', () => {
         color: getSketchColorMock()
       }]
     } as SketchMSStyle;
-    const root = {};
-    sketchStyleParserService.parseShadows(obj, root);
     const color = sketchStyleParserService['parseColors'](obj.shadows[0].color);
-    expect(root).toEqual({ css: { 'box-shadow': `123px 53px 12px 23px ${color.rgba}` } });
+    expect(sketchStyleParserService.transformShadows(obj)).toEqual({ 'box-shadow': `123px 53px 12px 23px ${color.rgba}`});
   });
 
   describe('when parse blur', () => {
     it('should parse positive radius blur', () => {
       const obj = {blur: {radius: 96}} as SketchMSStyle;
-      const root = {};
-      sketchStyleParserService.parseBlur(obj, root);
-      expect(root).toEqual({ css: { filter: `blur(${obj.blur.radius}px);` } });
+      expect(sketchStyleParserService.transformBlur(obj)).toEqual({filter: `blur(${obj.blur.radius}px);`});
     });
 
     it('should skip for negative blur radius', () => {
       const obj = {blur: {radius: -123}} as SketchMSStyle;
-      const root = {};
-      sketchStyleParserService['parseBlur'](obj, root);
-      expect(root).toEqual({});
+      expect(sketchStyleParserService.transformBlur(obj)).toEqual({});
     });
 
     it('should skip for 0 blur radius', () => {
       const obj = {blur: {radius: 0}} as SketchMSStyle;
-      const root = {};
-      sketchStyleParserService['parseBlur'](obj, root);
-      expect(root).toEqual({});
+      expect(sketchStyleParserService.transformBlur(obj)).toEqual({});
     });
 
     it('should skip on undefined blur', () => {
       const obj = {} as SketchMSStyle;
-      const root = {};
-      sketchStyleParserService['parseBlur'](obj, root);
-      expect(root).toEqual({});
+      expect(sketchStyleParserService.transformBlur(obj)).toEqual({});
     });
   });
 
@@ -206,10 +182,8 @@ describe('SketchStyleParserService', () => {
           color: getSketchColorMock()
         }]
       } as SketchMSStyle;
-      const root = {};
-      sketchStyleParserService['parseBorders'](obj, root);
       const color = sketchStyleParserService['parseColors'](obj.borders[0].color);
-      expect(root).toEqual({ css: { 'box-shadow': `0 0 0 129px ${color.rgba}`}});
+      expect(sketchStyleParserService.transformBorders(obj)).toEqual({'box-shadow': `0 0 0 129px ${color.rgba}`});
     });
 
     it('should skip for negative thickness border', () => {
@@ -220,9 +194,7 @@ describe('SketchStyleParserService', () => {
           color: getSketchColorMock()
         }]
       } as SketchMSStyle;
-      const root = {};
-      sketchStyleParserService['parseBorders'](obj, root);
-      expect(root).toEqual({});
+      expect(sketchStyleParserService.transformBorders(obj)).toEqual({});
     });
 
     it('should set inet for boder type inside', () => {
@@ -233,10 +205,8 @@ describe('SketchStyleParserService', () => {
           color: getSketchColorMock()
         }]
       } as SketchMSStyle;
-      const root = {};
-      sketchStyleParserService['parseBorders'](obj, root);
       const color = sketchStyleParserService['parseColors'](obj.borders[0].color);
-      expect(root).toEqual({css: {'box-shadow': `0 0 0 129px ${color.rgba} inset`}});
+      expect(sketchStyleParserService.transformBorders(obj)).toEqual({'box-shadow': `0 0 0 129px ${color.rgba} inset`});
     });
 
     it('should skip fallback to default on center position', () => {
@@ -247,10 +217,8 @@ describe('SketchStyleParserService', () => {
           color: getSketchColorMock()
         }]
       } as SketchMSStyle;
-      const root = {};
-      sketchStyleParserService['parseBorders'](obj, root);
       const color = sketchStyleParserService['parseColors'](obj.borders[0].color);
-      expect(root).toEqual({css: {'box-shadow': `0 0 0 129px ${color.rgba}`}});
+      expect(sketchStyleParserService.transformBorders(obj)).toEqual({'box-shadow': `0 0 0 129px ${color.rgba}`});
     });
 
     it('should skip fallback to default on outside position', () => {
@@ -261,24 +229,18 @@ describe('SketchStyleParserService', () => {
           color: getSketchColorMock()
         }]
       } as SketchMSStyle;
-      const root = {};
-      sketchStyleParserService['parseBorders'](obj, root);
       const color = sketchStyleParserService['parseColors'](obj.borders[0].color);
-      expect(root).toEqual({css: {'box-shadow': `0 0 0 129px ${color.rgba}`}});
+      expect(sketchStyleParserService.transformBorders(obj)).toEqual({'box-shadow': `0 0 0 129px ${color.rgba}`});
     });
 
     it('should skip on empty border', () => {
       const obj = {borders: []} as SketchMSStyle;
-      const root = {};
-      sketchStyleParserService['parseBorders'](obj, root);
-      expect(root).toEqual({});
+      expect(sketchStyleParserService.transformBorders(obj)).toEqual({});
     });
 
     it('should skip on undefined border', () => {
       const obj = {} as SketchMSStyle;
-      const root = {};
-      sketchStyleParserService['parseBorders'](obj, root);
-      expect(root).toEqual({});
+      expect(sketchStyleParserService.transformBorders(obj)).toEqual({});
     });
   });
 
@@ -295,15 +257,11 @@ describe('SketchStyleParserService', () => {
           }
         }]
       } as SketchMSStyle;
-      const root = {};
-      sketchStyleParserService.parseFills(obj, root);
       const color = sketchStyleParserService['parseColors'](obj.fills[0].color);
       const colorStop = sketchStyleParserService['parseColors'](obj.fills[0].gradient.stops[0].color);
-      expect(root).toEqual({
-        css: {
-          'background-color': color.rgba,
-          'background': `linear-gradient(90deg, ${colorStop.rgba} 83.5923120242395%)`
-        }
+      expect(sketchStyleParserService.transformFills(obj)).toEqual({
+        'background-color': color.rgba,
+        'background': `linear-gradient(90deg, ${colorStop.rgba} 83.5923120242395%)`
       });
     });
 
@@ -319,15 +277,11 @@ describe('SketchStyleParserService', () => {
           }
         }]
       } as SketchMSStyle;
-      const root = {};
-      sketchStyleParserService.parseFills(obj, root);
       const color = sketchStyleParserService['parseColors'](obj.fills[0].color);
       const colorStop = sketchStyleParserService['parseColors'](obj.fills[0].gradient.stops[0].color);
-      expect(root).toEqual({
-        css: {
-          'background-color': color.rgba,
-          'background': `linear-gradient(90deg, ${colorStop.rgba})`
-        }
+      expect(sketchStyleParserService.transformFills(obj)).toEqual({
+        'background-color': color.rgba,
+        'background': `linear-gradient(90deg, ${colorStop.rgba})`
       });
     });
 
@@ -343,15 +297,11 @@ describe('SketchStyleParserService', () => {
           }
         }]
       } as SketchMSStyle;
-      const root = {};
-      sketchStyleParserService.parseFills(obj, root);
       const color = sketchStyleParserService['parseColors'](obj.fills[0].color);
       const colorStop = sketchStyleParserService['parseColors'](obj.fills[0].gradient.stops[0].color);
-      expect(root).toEqual({
-        css: {
-          'background-color': color.rgba,
-          'background': `linear-gradient(90deg, ${colorStop.rgba})`
-        }
+      expect(sketchStyleParserService.transformFills(obj)).toEqual({
+        'background-color': color.rgba,
+        'background': `linear-gradient(90deg, ${colorStop.rgba})`
       });
     });
   });

--- a/src/app/editor/viewer/lib/parsers/sketch-style-parser.service.ts
+++ b/src/app/editor/viewer/lib/parsers/sketch-style-parser.service.ts
@@ -1,5 +1,6 @@
 import { BinaryPropertyListParserService } from './bplist-parser.service';
 import { Injectable } from '@angular/core';
+import { SketchData } from '../sketch.service';
 
 /**
  * border Type:
@@ -13,267 +14,300 @@ export enum BorderType {
   CENTER = 0
 }
 
+export enum SupportScore {
+  UNKNOWN = 1,
+  DROPPED = 2,
+  LEGACY = 3,
+  LATEST = 4,
+  EDGE = 5
+}
+
 @Injectable({
   providedIn: 'root'
 })
 export class SketchStyleParserService {
   constructor(private binaryPlistParser: BinaryPropertyListParserService) {}
-  public visit(pages: Array<SketchMSPage>) {
-    pages.forEach(page => {
+  public visit(sketch: SketchData) {
+    const supp = this.checkSupport(sketch);
+
+    if (supp < SupportScore.DROPPED) {
+      throw new Error('No longer supported version');
+    }
+
+    sketch.pages.forEach(page => {
       if (page.layers) {
         page.layers.map(layer => this.visitObject(layer, page, layer));
       }
     });
+    return supp;
   }
 
-  visitObject(obj: any, parent: any, root: any) {
-    for (const property in obj) {
-      if (obj.hasOwnProperty(property)) {
-        if (typeof obj[property] === 'object') {
+  checkSupport(sketch: SketchData) {
+    const ver = Number.parseInt(sketch.meta.appVersion.split('.')[0]);
+    if (Number.isNaN(ver)) {
+      return SupportScore.UNKNOWN;
+    } else if (ver < 49) {
+      return SupportScore.DROPPED;
+    } else if (ver >= 49 && ver < 52) {
+      return SupportScore.LEGACY;
+    } else if (ver === 52) {
+      return SupportScore.LATEST;
+    } else {
+      return SupportScore.EDGE;
+    }
+  }
+
+  visitObject(current: any, parent: any, root: any) {
+    for (const property in current) {
+      if (current.hasOwnProperty(property)) {
+        if (typeof current[property] === 'object') {
           // visit child
-          if (obj[property].frame && obj[property].frame._class === 'rect') {
-            this.visitObject(obj[property], obj, obj[property]);
+          if (current[property].frame && current[property].frame._class === 'rect') {
+            this.visitObject(current[property], current, current[property]);
           } else {
-            this.visitObject(obj[property], obj, root);
+            this.visitObject(current[property], current, root);
           }
         } else if (property === '_class') {
-          switch (obj[property]) {
-            case 'color':
-              obj._values = this.parseColors(obj as SketchMSColor);
-              break;
+          const obj = this.parseObject(current);
+          const attr = this.parseAttributeString(current);
+          const grp = this.parseGroup(current);
+          const pol = this.polyfill(current);
 
-            case 'symbolMaster':
-              this.setStyle(obj, root, {
-                'background-color': this.parseColors(
-                  (obj as SketchMSSymbolMaster).backgroundColor
-                ).rgba
-              });
-              break;
-
-            case 'style':
-              this.parseStyleInformation(obj, root);
-              break;
-            case 'text':
-              this.parseText(obj, root);
-              break;
-
-            default:
-              if ((obj as SketchMSPage).rotation) {
-                this.setStyle(obj, root, {
-                  transform: `rotate(${obj.rotation}deg)`
-                });
-              }
-
-              if ((obj as SketchMSPage).fixedRadius) {
-                this.setStyle(obj, root, {
-                  'border-radius': `${obj.fixedRadius}px`
-                });
-              }
-
-              if ((obj as SketchMSGraphicsContextSettings).opacity) {
-                this.setStyle(obj, root, {
-                  opacity: `${obj.opacity}`
-                });
-              }
-          }
-
-          if ((obj as SketchMSLayer).frame) {
-            this.setStyle(obj, root, {
-              display: 'block',
-              position: 'absolute',
-              left: `${obj.frame.x}px`,
-              top: `${obj.frame.y}px`,
-              width: `${obj.frame.width}px`,
-              height: `${obj.frame.height}px`,
-              visibility: obj.isVisible ? 'visible' : 'hidden'
-            });
-          }
+          this.setText(current, root, attr.text);
+          this.setText(current, root, obj.text);
+          this.setText(current, root, pol.text);
+          this.setStyle(current, root, obj.style);
+          this.setStyle(current, root, grp.style);
         }
       }
     }
     return parent;
   }
 
-  parseText(obj: any, root: any) {
-    this.parseTextColor(obj, root);
-    this.parseParagraphStyle(obj, root);
-    this.parseTextFont(obj, root);
-    this.parseAttributeString(obj, root);
+  /**
+   * Parse attibutes
+   */
+  parseAttributeString(node: SketchMSLayer) {
+    const obj = node.attributedString;
+    if (obj && obj.hasOwnProperty('archivedAttributedString')) {
+      const archive = this.binaryPlistParser.parse64Content(obj.archivedAttributedString._archive);
+      if (archive) {
+        switch (archive.$key) {
+          case 'ascii':
+            return {
+              text: archive.$value
+            };
+        }
+      }
+    }
+    return {};
   }
 
   /**
-   * Parse text font if nothing is found
-   * fallback to current page font.
-   *
-   * @param obj   The current layer
-   * @param root  The root layer
+   * Parse high level wapper attributes
    */
-  parseTextFont(obj: SketchMSLayer, root: any) {
-    const MSAttributedStringFontAttribute =
-      obj.style.textStyle.encodedAttributes.MSAttributedStringFontAttribute;
-    if (MSAttributedStringFontAttribute.hasOwnProperty('_archive')) {
-      const parsedMSAttributedStringFontAttribute = this.binaryPlistParser.parse64Content(
-        MSAttributedStringFontAttribute._archive
-      );
-      (root.style.textStyle.encodedAttributes
-        .MSAttributedStringFontAttribute as any)._transformed = parsedMSAttributedStringFontAttribute;
-    } else if (
-      MSAttributedStringFontAttribute.hasOwnProperty('_class') &&
-      MSAttributedStringFontAttribute._class === 'fontDescriptor'
-    ) {
-      this.setStyle(obj, root, {
-        'font-family': `${
-          MSAttributedStringFontAttribute.attributes.name
-        }, 'Roboto', sans-serif`,
-        'font-size': `${MSAttributedStringFontAttribute.attributes.size}px`
-      });
+  parseGroup(layer: SketchMSLayer) {
+    return {
+      style: (layer as SketchMSLayer).frame ? {
+        display: 'block',
+        position: 'absolute',
+        left: `${layer.frame.x}px`,
+        top: `${layer.frame.y}px`,
+        width: `${layer.frame.width}px`,
+        height: `${layer.frame.height}px`,
+        visibility: layer.isVisible ? 'visible' : 'hidden'
+      } : {}
+    };
+  }
+
+  /**
+   * Parse object attribute
+   */
+  parseObject(layer: any) {
+    switch (layer._class) {
+    case 'symbolMaster':
+      return {
+        style: {
+          ...this.transformSymbolMaster(layer)
+        }
+      };
+
+    case 'style':
+      return {
+        style: {
+          ...this.transformBlur(layer),
+          ...this.transformBorders(layer),
+          ...this.transformFills(layer),
+          ...this.transformShadows(layer)
+        }
+      };
+
+    case 'text':
+      return {
+        text: this.transformTextContent(layer),
+        style: {
+          ...this.transformTextColor(layer),
+          ...this.transformParagraphStyle(layer),
+          ...this.transformTextFont(layer)
+        }
+      };
+
+    default:
+      return {
+        style: {
+          ...(layer as SketchMSPage).rotation ? {
+            transform: `rotate(${layer.rotation}deg)`
+          } : {},
+          ...(layer as SketchMSPage).fixedRadius ? {
+            'border-radius': `${layer.fixedRadius}px`
+          } : {},
+          ...(layer as SketchMSGraphicsContextSettings).opacity ? {
+            opacity: `${layer.opacity}`
+          } : {}
+        }
+      };
     }
   }
 
   /**
-   * Parse attibutes (not used at the moment)
-   *
-   * @param obj   The current layer
-   * @param root  The root layer
+   * Best effort fallback polyfill
    */
-  parseAttributeString(obj: SketchMSLayer, root: any) {
-    const attributedString = obj.attributedString;
-    if (attributedString.hasOwnProperty('archivedAttributedString')) {
-      const archivedAttributedString = attributedString.archivedAttributedString
-        ._archive as string;
-      const parsedArchivedAttributedString = this.binaryPlistParser.parse64Content(
-        archivedAttributedString
-      );
-      (root.attributedString
-        .archivedAttributedString as any)._transformed = parsedArchivedAttributedString;
-    }
+  polyfill(layer: any) {
+    return {
+      text: layer.name,
+    };
   }
 
-  /**
-   * Parse paragraph alignment (not used at the moment)
-   *
-   * @param obj   The current layer
-   * @param root  The root layer
-   */
-  parseParagraphStyle(obj: SketchMSLayer, root: any) {
-    const encodedAttributes = obj.style.textStyle.encodedAttributes;
-    if (encodedAttributes.hasOwnProperty('NSParagraphStyle')) {
-      const NSParagraphStyle = root.style.textStyle.encodedAttributes
-        .NSParagraphStyle._archive as string;
-      const parsedNSParagraphStyle = this.binaryPlistParser.parse64Content(
-        NSParagraphStyle
-      );
-      (root.style.textStyle.encodedAttributes
-        .NSParagraphStyle as any)._transformed = parsedNSParagraphStyle;
-    }
+  transformSymbolMaster(layer: SketchMSSymbolMaster) {
+    const obj = layer.backgroundColor;
+    return {
+      'background-color': this.parseColors(obj).rgba
+    };
   }
 
-  /**
-   * Parse text colors, if nothing is found
-   * fallback to black color
-   *
-   * @param obj   The current layer
-   * @param root  The root layer
-   */
-  parseTextColor(obj: SketchMSLayer, root: any) {
-    const encodedAttributes = obj.style.textStyle.encodedAttributes;
-    if (encodedAttributes.hasOwnProperty('MSAttributedStringColorAttribute')) {
-      this.setStyle(obj, root, {
+  transformTextContent(node: SketchMSLayer) {
+    return node.attributedString.string;
+  }
+
+  transformTextFont(node: SketchMSLayer) {
+    const obj = node.style.textStyle.encodedAttributes.MSAttributedStringFontAttribute;
+    if (obj.hasOwnProperty('_class') && obj._class === 'fontDescriptor') {
+      return {
+        'font-family': `'${obj.attributes.name}', 'Roboto', 'sans-serif'`,
+        'font-size': `${obj.attributes.size}px`
+      };
+    } else if (obj.hasOwnProperty('_archive')) {
+      // TODO: Handle legacy
+      // const archive = this.binaryPlistParser.parse64Content(obj._archive);
+      // (scope.style.textStyle.encodedAttributes.MSAttributedStringFontAttribute as any)._transformed = archive;
+      return {};
+    }
+    return {};
+  }
+
+  transformParagraphStyle(node: SketchMSLayer) {
+    const obj = node.style.textStyle.encodedAttributes;
+    if (obj.hasOwnProperty('NSParagraphStyle')) {
+      // TODO: Handle legacy
+      // const archive = this.binaryPlistParser.parse64Content(scope.style.textStyle.encodedAttributes.NSParagraphStyle._archive);
+      // (scope.style.textStyle.encodedAttributes.NSParagraphStyle as any)._transformed = archive;
+      return {};
+    }
+    return {};
+  }
+
+  transformTextColor(node: SketchMSLayer) {
+    const obj = node.style.textStyle.encodedAttributes;
+    if (obj.hasOwnProperty('MSAttributedStringColorAttribute')) {
+      return {
         color: this.parseColors(
-          encodedAttributes.MSAttributedStringColorAttribute
+          obj.MSAttributedStringColorAttribute
         ).rgba
-      });
-    } else if (encodedAttributes.hasOwnProperty('NSColor')) {
-      const NSColor = encodedAttributes.NSColor._archive as string;
-      const parsedNSColor = this.binaryPlistParser.parse64Content(NSColor);
-      (root.style.textStyle.encodedAttributes
-        .NSColor as any)._transformed = parsedNSColor;
-    } else {
-      this.setStyle(obj, root, {
-        color: 'black'
-      });
+      };
+    } else if (obj.hasOwnProperty('NSColor')) {
+      // TODO: Handle legacy
+      // const archive = this.binaryPlistParser.parse64Content(obj.NSColor._archive);
+      // (scope.style.textStyle.encodedAttributes.NSColor as any)._transformed = archive;
+      return {};
     }
+    return {
+      color: 'black'
+    };
   }
 
-  parseStyleInformation(obj: any, root: any) {
-    // blur
-    this.parseBlur(obj, root);
-    // borders
-    this.parseBorders(obj, root);
-    // fills
-    this.parseFills(obj, root);
-    // innerShadows and shadows
-    this.parseShadows(obj, root);
+  /**
+   * Translate blur to CSS
+   */
+  transformBlur(node: SketchMSStyle) {
+    const obj = node.blur;
+    return obj && obj.radius > 0 ? {
+      filter: `blur(${obj.radius}px);`
+    } : {};
   }
 
-  parseBlur(obj: SketchMSStyle, root: any) {
-    const blur = obj.blur;
-    if (blur && blur.radius > 0) {
-      this.setStyle(obj, root, {
-        filter: `blur(${blur.radius}px);`
-      });
+  transformBorders(node: SketchMSStyle) {
+    const obj = node.borders;
+    if (!obj || obj.length === 0) {
+      return {};
     }
-  }
 
-  parseBorders(obj: SketchMSStyle, root: any) {
-    const borders = obj.borders;
-    if (borders && borders.length > 0) {
-      const bordersStyles = borders.reduce((acc, border) => {
-        if (border.thickness > 0) {
-          const color = this.parseColors(border.color);
-          let shadow = `0 0 0 ${border.thickness}px ${color.rgba}`;
-          if (border.position === BorderType.INSIDE) {
-            shadow += ' inset';
-          }
-          return [shadow, ...acc];
+    const bordersStyles = obj.reduce((acc, border) => {
+      if (border.thickness > 0) {
+        const color = this.parseColors(border.color);
+        let shadow = `0 0 0 ${border.thickness}px ${color.rgba}`;
+        if (border.position === BorderType.INSIDE) {
+          shadow += ' inset';
         }
-        return acc;
-      }, []);
-
-      if (bordersStyles.length > 0) {
-        this.setStyle(obj, root, {
-          'box-shadow': bordersStyles.join(',')
-        });
+        return [shadow, ...acc];
       }
-    }
+      return acc;
+    }, []);
+
+    return bordersStyles.length > 0 ? {
+      'box-shadow': bordersStyles.join(',')
+    } : {};
   }
 
-  parseFills(obj: SketchMSStyle, root: any) {
-    const fills = obj.fills || [];
-    if (fills.length > 0) {
-      // we only support one fill: take the first one!
-      // ignore the other fills
-      const firstFill = fills[0];
+  transformFills(node: SketchMSStyle) {
+    const obj = node.fills;
+    if (!obj || obj.length === 0) {
+      return {};
+    }
 
-      this.setStyle(obj, root, {
-        'background-color': `${this.parseColors(firstFill.color).rgba}`
-      });
+    // we only support one fill: take the first one!
+    // ignore the other fills
+    const firstFill = obj[0];
 
-      if (firstFill.gradient) {
-        const fillsStyles: string[] = [];
-        firstFill.gradient.stops.forEach(stop => {
-          let fill = `${this.parseColors(stop.color).rgba}`;
-          if (stop.position >= 0 && stop.position <= 1) {
-            fill += ` ${stop.position * 100}%`;
-          }
-          fillsStyles.push(fill);
-        });
-
-        if (fillsStyles.length > 0) {
-          // apply gradient, if multiple fills
-          // default angle is 90deg
-          this.setStyle(obj, root, {
-            background: `linear-gradient(90deg, ${fillsStyles.join(',')})`
+    return {
+      ...(() => {
+        if (firstFill.gradient) {
+          const fillsStyles: string[] = [];
+          firstFill.gradient.stops.forEach(stop => {
+            let fill = `${this.parseColors(stop.color).rgba}`;
+            if (stop.position >= 0 && stop.position <= 1) {
+              fill += ` ${stop.position * 100}%`;
+            }
+            fillsStyles.push(fill);
           });
+
+          if (fillsStyles.length > 0) {
+            // apply gradient, if multiple fills
+            // default angle is 90deg
+            return {
+              background: `linear-gradient(90deg, ${fillsStyles.join(',')})`
+            };
+          }
         }
-      }
-    }
+      })(),
+      'background-color': `${this.parseColors(firstFill.color).rgba}`
+    };
   }
 
-  parseShadows(obj: SketchMSStyle, root: any) {
-    const innerShadows = obj.innerShadows || [];
-    const shadows = obj.shadows || [];
+  transformShadows(node: SketchMSStyle) {
+    const innerShadows = node.innerShadows;
+    const shadows = node.shadows;
     const shadowsStyles: string[] = [];
+
     if (innerShadows) {
       innerShadows.forEach(innerShadow => {
         const color = this.parseColors(innerShadow.color);
@@ -294,30 +328,14 @@ export class SketchStyleParserService {
         );
       });
     }
-    if (innerShadows.length > 0 || shadows.length > 0) {
-      this.setStyle(obj, root, {
-        'box-shadow': shadowsStyles.join(',')
-      });
-    }
+
+    return shadowsStyles.length > 0 ? {
+      'box-shadow': shadowsStyles.join(',')
+    } : {};
   }
 
-  parseColors(color: SketchMSColor | undefined) {
-    if (typeof color === 'undefined') {
-      return {
-        hex: '#00FFFFFF',
-        rgba: 'rgba(255,255,255,1)',
-        raw: {
-          red: 255,
-          green: 255,
-          blue: 255,
-          alpha: 1
-        }
-      };
-    }
-
-    const styles = {};
+  parseColors(color: SketchMSColor) {
     const { red, green, blue, alpha } = color;
-
     return {
       hex: this.sketch2hex(red, green, blue, alpha),
       rgba: this.sketch2rgba(red, green, blue, alpha),
@@ -339,17 +357,6 @@ export class SketchStyleParserService {
     return `rgba(${this.rgba(r)},${this.rgba(g)},${this.rgba(b)},${a})`;
   }
 
-  setStyle(obj: any, root: any, style: { [key: string]: string }) {
-    root.css = root.css || {};
-    obj.css = obj.css || {};
-    for (const property in style) {
-      if (style.hasOwnProperty(property)) {
-        root.css[property] = style[property];
-        obj.css[property] = style[property];
-      }
-    }
-  }
-
   sketch2hex(r: number, g: number, b: number, a: number) {
     if (r > 255 || g > 255 || b > 255 || a > 255) {
       return '';
@@ -365,5 +372,23 @@ export class SketchStyleParserService {
           .toString(16)
           .substr(1))
     );
+  }
+
+  setStyle(obj: any, root: any, style: { [key: string]: string }) {
+    root.css = root.css || {};
+    obj.css = obj.css || {};
+    for (const property in style) {
+      if (style.hasOwnProperty(property)) {
+        root.css[property] = style[property];
+        obj.css[property] = style[property];
+      }
+    }
+  }
+
+  setText(obj: any, root: any, text: string) {
+    if (text && (!root.text || !obj.text)) {
+      root.text = text;
+      obj.text = text;
+    }
   }
 }

--- a/src/app/editor/viewer/lib/sketch-layer.component.ts
+++ b/src/app/editor/viewer/lib/sketch-layer.component.ts
@@ -111,8 +111,7 @@ export class SketchLayerComponent implements OnInit, AfterContentInit {
 
   isTextContent() {
     if ((this.layer._class as 'text') === 'text') {
-      this.textContent = (this
-        .layer as SketchMSSymbolMaster).attributedString.string;
+      this.textContent = (this.layer as any).text;
     }
   }
 


### PR DESCRIPTION
Many integration difficulties were encountered during the rewriting process of the parser, so I decided to bring all the improvements from the rewrite back to the current parser.

This update includes a version guard at the parser entry, a complete rewrite of each method to separate CSS injection from parsing and fix some bplist parsing error for older version.