### PR TITLE
core: add workspace recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "ms-vscode.vscode-typescript-tslint-plugin",
+        "angular.ng-template"
+    ]
+}


### PR DESCRIPTION
This will recommend extensions within VSCode. I didn't installed ts lint extension and I never noticed the problem with `"arandomstring"` vs  `'arandomstring'`. 

**Without ts-lint extensions**:
![2019-03-01 08_24_02-window](https://user-images.githubusercontent.com/17835373/53622867-82df1980-3bfb-11e9-808a-bfc45db4a42d.png)
**With
![2019-03-01 08_24_38-window](https://user-images.githubusercontent.com/17835373/53622898-9ab69d80-3bfb-11e9-9452-31d775009cf0.png)
 ts-lint extensions**:


This will help our contributers to see this in advance without waiting for the pre-commit checks.


![2019-03-01 08_19_12-window](https://user-images.githubusercontent.com/17835373/53622913-a73af600-3bfb-11e9-8b1f-eb38edd527d4.png)


![2019-03-01 08_19_49-window](https://user-images.githubusercontent.com/17835373/53622915-a86c2300-3bfb-11e9-9dcc-2fc82352c455.png)

 