### PR TITLE
feat(codegen): angular element support 244

### DIFF
--- a/projects/web-codegen/src/lib/angular-aggregator.service.ts
+++ b/projects/web-codegen/src/lib/angular-aggregator.service.ts
@@ -46,14 +46,14 @@ export class AngularAggregatorService {
       },
       {
         kind: 'angular',
-        value: this.renderSpec(current.name, options),
+        value: this.renderSpec(current.name),
         language: 'typescript',
         uri: `${options.componentDir}/${fileName}.spec.ts`
       }
     ];
   }
 
-  private renderComponent(name: string, options: WebCodeGenOptions) {
+  renderComponent(name: string, options: WebCodeGenOptions) {
     const className = this.formatService.className(name);
     const normalizedName = this.formatService.normalizeName(name);
     const tagName = `${options.xmlPrefix}${normalizedName}`;
@@ -68,7 +68,7 @@ import { Component } from '@angular/core';
 export class ${className}Component {}`;
   }
 
-  private renderSpec(name: string, options: WebCodeGenOptions) {
+  private renderSpec(name: string) {
     const className = this.formatService.className(name);
     const fileName = this.formatService.normalizeName(name);
     return `\

--- a/projects/web-codegen/src/lib/angular-element-aggregator.service.ts
+++ b/projects/web-codegen/src/lib/angular-element-aggregator.service.ts
@@ -1,0 +1,286 @@
+import { Injectable } from '@angular/core';
+import { WebCodeGenOptions } from './web-codegen';
+import { WebAggregatorService } from './web-aggregator.service';
+import { FormatService } from '@xlayers/sketch-lib';
+import { AngularAggregatorService } from './angular-aggregator.service';
+
+const ELEMENT_MODULE_FILENAME = 'app.module.ts';
+const EXTRA_WEBPACK_CONFIG_FILENAME = 'webpack.extra.js';
+const COPY_BUNDLES_SCRIPT_FILENAME = 'copy.bundles.js';
+const DIST_FOLDER_NAME = 'dist';
+const BUNDLES_TARGET_PATH = `${DIST_FOLDER_NAME}/bundles`;
+const SAMPLE_INDEX_FILENAME = 'index.html';
+const ELEMENT_BUNDLE_FILENAME = 'main.js';
+const ELEMENT_CREATOR_APPNAME = 'element-creator';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AngularElementAggregatorService {
+  constructor(
+    private readonly formatService: FormatService,
+    private readonly webAggretatorService: WebAggregatorService,
+    private readonly angularAggregatorService: AngularAggregatorService
+  ) {}
+
+  aggreate(current: SketchMSLayer, options: WebCodeGenOptions) {
+    const fileName = this.formatService.normalizeName(current.name);
+    const componentPathName = `${options.componentDir}/${fileName}.component`;
+    return [
+      {
+        uri: 'README.md',
+        value: this.renderReadme(current.name, options),
+        language: 'markdown',
+        kind: 'text'
+      },
+      ...this.webAggretatorService.aggreate(current, options).map(file => {
+        switch (file.language) {
+          case 'html':
+            return {
+              ...file,
+              kind: 'angular',
+              uri: `${options.componentDir}/${fileName}.component.html`
+            };
+
+          case 'css':
+            return {
+              ...file,
+              kind: 'angular',
+              uri: `${options.componentDir}/${fileName}.component.css`
+            };
+
+          default:
+            return {
+              ...file,
+              kind: 'angularElement'
+            };
+        }
+      }),
+      {
+        uri: `${componentPathName}.ts`,
+        value: this.angularAggregatorService.renderComponent(current.name, options),
+        language: 'typescript',
+        kind: 'angular',
+      },
+      {
+        uri: ELEMENT_MODULE_FILENAME,
+        value: this.renderElementModule(current.name, options, componentPathName),
+        language: 'typescript',
+        kind: 'angularElement'
+      },
+      {
+        uri: EXTRA_WEBPACK_CONFIG_FILENAME,
+        value: this.renderWebpackExtra(),
+        language: 'javascript',
+        kind: 'angularElement'
+      },
+      {
+        uri: COPY_BUNDLES_SCRIPT_FILENAME,
+        value: this.renderCopyUmdBundlesScript(),
+        language: 'javascript',
+        kind: 'angularElement'
+      },
+      {
+        uri: SAMPLE_INDEX_FILENAME,
+        value: this.renderSampleIndexHtml(current.name, options),
+        language: 'html',
+        kind: 'angularElement'
+      }
+    ];
+  }
+
+
+  private renderReadme(name: string, options: WebCodeGenOptions) {
+    const className = this.formatService.className(name);
+    const normalizedName = this.formatService.normalizeName(name);
+    const tagName = `${options.xmlPrefix}${normalizedName}`;
+    const codeSpan = text => '`' + text + '`';
+    const codeBlock = '```';
+    return `
+**Notice:**
+The current implement of [Angular Elements](https://angular.io/guide/elements) is in MVP (minimum viable product) state.
+Some features like content projection are not supported yet.
+Keep in mind that the following build process and feature support will be improved in the future.
+The creation of the bundled Angular Element is based on the process defined by [Manfred Steyer](https://twitter.com/manfredsteyer)'s example from
+[${codeSpan('ngx-build-plus')}](https://github.com/manfredsteyer/ngx-build-plus).
+
+## How to use the ${codeSpan(name)} Angular Element
+
+1. In order to use an Angular Element as a web component, it first needs to be created, e.g. in the following way:
+
+    a) Use the Angular CLI to create a minimal app which will be used to create the Angular Element:
+    ${codeBlock}
+    ng new ${ELEMENT_CREATOR_APPNAME} --minimal --style css --routing false
+    cd ${ELEMENT_CREATOR_APPNAME}
+    ${codeBlock}
+
+    b) Add necessary dependencies for the following steps:
+    ${codeBlock}
+    ng add @angular/elements
+    ng add ngx-build-plus
+    npm install @webcomponents/custom-elements --save
+    npm install --save-dev copy
+    ${codeBlock}
+
+    c) Download and extract the files of this generation. Place the files of the ${codeSpan(className)}
+    into your standard ${codeSpan('src/app')} folder. Replace the ${codeSpan(ELEMENT_MODULE_FILENAME)} and remove the sample ${codeSpan('app.component.ts')}.
+    Extract the files ${codeSpan(EXTRA_WEBPACK_CONFIG_FILENAME)} and ${codeSpan(COPY_BUNDLES_SCRIPT_FILENAME)} into the project root.
+
+    e) Build the Angular Element:
+    ${codeBlock}
+    ng build --prod --extraWebpackConfig ${EXTRA_WEBPACK_CONFIG_FILENAME} --output-hashing none --single-bundle true
+    ${codeBlock}
+
+2. After the creation of the Angular Element, it can be found as single file
+web component ${codeSpan(DIST_FOLDER_NAME + '/' + ELEMENT_CREATOR_APPNAME + '/' + ELEMENT_BUNDLE_FILENAME)} and can be consumed in the following way:
+${codeBlock}
+  // index.html
+  <script src="./${DIST_FOLDER_NAME}/${ELEMENT_CREATOR_APPNAME}/${ELEMENT_BUNDLE_FILENAME}"></script>
+  <${tagName}></${tagName}>
+${codeBlock}
+
+However due to the bundle splitting approach, the different dependent bundles must be added manually,
+e.g. like described in the exported sample file ${codeSpan(SAMPLE_INDEX_FILENAME)}.
+In order to get those script you can run the script ${codeSpan(COPY_BUNDLES_SCRIPT_FILENAME)} file.
+${codeBlock}
+  node ./${COPY_BUNDLES_SCRIPT_FILENAME}
+${codeBlock}
+
+>  For more information about [web components and browser support](https://github.com/WebComponents/webcomponentsjs#browser-support)
+`;
+  }
+
+  private renderElementModule(name: string, options: WebCodeGenOptions, componentPathName: string) {
+    const className = this.formatService.className(name);
+    const componentName = `${className}Component`;
+    const normalizedName = this.formatService.normalizeName(name);
+    const tagName = `${options.xmlPrefix}${normalizedName}`;
+    return (
+      '' +
+      `
+import { BrowserModule } from '@angular/platform-browser';
+import { NgModule, Injector } from '@angular/core';
+import { createCustomElement } from '@angular/elements';
+
+import { ${componentName} } from './${componentPathName}';
+
+@NgModule({
+  imports: [
+    BrowserModule
+  ],
+  declarations: [
+    ${componentName}
+  ],
+  entryComponents: [
+    ${componentName}
+  ],
+})
+export class AppModule {
+  constructor(injector: Injector) {
+    const element = createCustomElement(${componentName} , { injector });
+    customElements.define('${tagName}', element);
+  }
+
+  ngDoBootstrap() { }
+}
+    `
+    );
+  }
+
+  private renderWebpackExtra() {
+    return `
+module.exports = {
+  "externals": {
+      "rxjs": "rxjs",
+      "@angular/core": "ng.core",
+      "@angular/common": "ng.common",
+      "@angular/platform-browser": "ng.platformBrowser",
+      "@angular/elements": "ng.elements"
+  }
+}
+    `;
+  }
+
+  private renderCopyUmdBundlesScript() {
+    return `
+//
+// This script copies over UMD bundles to the folder dist/bundles
+// If you call it manually, call it from your projects root
+// > node /${COPY_BUNDLES_SCRIPT_FILENAME}
+//
+
+const copy = require('copy');
+
+console.log('Copy UMD bundles ...');
+
+copy('node_modules/@angular/*/bundles/*.umd.js', '${BUNDLES_TARGET_PATH}', {}, _ => {});
+copy('node_modules/rxjs/bundles/*.js', '${BUNDLES_TARGET_PATH}/rxjs', {}, _ => {});
+copy('node_modules/zone.js/dist/*.js', '${BUNDLES_TARGET_PATH}/zone.js', {}, _ => {});
+copy('node_modules/core-js/client/*.js', '${BUNDLES_TARGET_PATH}/core-js', {}, _ => {});
+copy('node_modules/@webcomponents/custom-elements/*.js', '${BUNDLES_TARGET_PATH}/custom-elements', {}, _ => {});
+copy('node_modules/@webcomponents/custom-elements/src/native-shim*.js', '${BUNDLES_TARGET_PATH}/custom-elements/src', {}, _ => {});
+    `;
+  }
+
+  private renderSampleIndexHtml(name: string, options: WebCodeGenOptions) {
+    const normalizedName = this.formatService.normalizeName(name);
+    const tagName = `${options.xmlPrefix}${normalizedName}`;
+
+    return `
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>ElementsLoading</title>
+<base href=".">
+
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="icon" type="image/x-icon" href="favicon.ico">
+</head>
+<body>
+
+<!-- Consider putting the following UMD (!) bundles -->
+<!-- into a big one -->
+
+<!-- core-js for legacy browsers -->
+<script src="./${BUNDLES_TARGET_PATH}/core-js/core.js"></script>
+
+<!-- Zone.js -->
+<!--
+    Consider excluding zone.js when creating
+    custom Elements by using the noop zone.
+-->
+<script src="./${BUNDLES_TARGET_PATH}/zone.js/zone.js"></script>
+
+<!--
+    Polyfills for Browsers supporting
+    Custom Elements. Needed b/c we downlevel
+    to ES5. See: @webcomponents/custom-elements
+-->
+<script src="./${BUNDLES_TARGET_PATH}/custom-elements/src/native-shim.js"></script>
+
+<!-- Polyfills for Browsers not supporting
+        Custom Elements. See: @webcomponents/custom-elements
+-->
+<script src="./${BUNDLES_TARGET_PATH}/custom-elements/custom-elements.min.js"></script>
+
+<!-- Rx -->
+<script src="./${BUNDLES_TARGET_PATH}/rxjs/rxjs.umd.js"></script>
+
+<!-- Angular Packages -->
+<script src="./${BUNDLES_TARGET_PATH}/core/bundles/core.umd.js"></script>
+<script src="./${BUNDLES_TARGET_PATH}/common/bundles/common.umd.js"></script>
+<script src="./${BUNDLES_TARGET_PATH}/platform-browser/bundles/platform-browser.umd.js"></script>
+<script src="./${BUNDLES_TARGET_PATH}/elements/bundles/elements.umd.js"></script>
+
+<!-- Angular Element -->
+<script src="./${DIST_FOLDER_NAME}/${ELEMENT_CREATOR_APPNAME}/${ELEMENT_BUNDLE_FILENAME}"></script>
+
+<!-- Calling Custom Element -->
+<${tagName}></${tagName}>
+
+</body>
+</html>
+    `;
+  }
+}

--- a/projects/web-codegen/src/lib/web-codegen.service.ts
+++ b/projects/web-codegen/src/lib/web-codegen.service.ts
@@ -5,6 +5,7 @@ import { WebParserService } from './web-parser.service';
 import { WebAggregatorService } from './web-aggregator.service';
 import { VueAggregatorService } from './vue-aggregator.service';
 import { AngularAggregatorService } from './angular-aggregator.service';
+import { AngularElementAggregatorService } from './angular-element-aggregator.service';
 import { ReactAggregatorService } from './react-aggregator.service';
 import { LitElementAggregatorService } from './lit-element-aggregator.service';
 import { WebCodeGenOptions } from './web-codegen.d';
@@ -23,6 +24,7 @@ export class WebCodeGenService {
     private readonly webComponentAggretatorService: WebComponentAggregatorService,
     private readonly vueAggretatorService: VueAggregatorService,
     private readonly angularAggretatorService: AngularAggregatorService,
+    private readonly angularElementAggretatorService: AngularElementAggregatorService,
     private readonly litElementAggretatorService: LitElementAggregatorService,
     private readonly reactAggretatorService: ReactAggregatorService,
     private readonly stencilAggretatorService: StencilAggregatorService,
@@ -68,6 +70,11 @@ export class WebCodeGenService {
       case 'angular':
         return this.visitContent(current, data, options).concat(
           this.angularAggretatorService.aggreate(current, options)
+        );
+
+      case 'angularElement':
+        return this.visitContent(current, data, options).concat(
+          this.angularElementAggretatorService.aggreate(current, options)
         );
 
       case 'litElement':

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -28,6 +28,7 @@ export class AppComponent {
     readonly translate: TranslateService) {
 
       iconRegistry.addSvgIcon('angular', sanitizer.bypassSecurityTrustResourceUrl('assets/codegen/angular.svg'));
+      iconRegistry.addSvgIcon('angularElement', sanitizer.bypassSecurityTrustResourceUrl('assets/codegen/angularElement.svg'));
       iconRegistry.addSvgIcon('react', sanitizer.bypassSecurityTrustResourceUrl('assets/codegen/react.svg'));
       iconRegistry.addSvgIcon('vue', sanitizer.bypassSecurityTrustResourceUrl('assets/codegen/vue.svg'));
       iconRegistry.addSvgIcon('wc', sanitizer.bypassSecurityTrustResourceUrl('assets/codegen/wc.svg'));

--- a/src/app/editor/code/editor-container/codegen/angular-element-codegen.service.ts
+++ b/src/app/editor/code/editor-container/codegen/angular-element-codegen.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import { WebCodeGenService } from '@xlayers/web-codegen';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AngularElementCodeGenService {
+  constructor(
+    private readonly webCodeGen: WebCodeGenService,
+  ) {}
+
+  buttons() {
+    return {
+      stackblitz: false
+    };
+  }
+
+  generate(data: SketchMSData) {
+    const generatedFiles = data.pages.flatMap(page =>
+      this.webCodeGen.aggreate(page, data, { mode: 'angularElement' })
+    );
+
+    return [
+      ...generatedFiles
+    ];
+  }
+}

--- a/src/app/editor/code/editor-container/codegen/codegen.module.ts
+++ b/src/app/editor/code/editor-container/codegen/codegen.module.ts
@@ -5,6 +5,7 @@ import { VueCodeGenService } from './vue-codegen.service';
 import { WebComponentCodeGenService } from './web-component-codegen.service';
 import { StencilCodeGenService } from './stencil-codegen.service';
 import { AngularCodeGenService } from './angular-codegen.service';
+import { AngularElementCodeGenService } from './angular-element-codegen.service';
 import { LitElementCodeGenService } from './lit-element-codegen.service';
 import { XamarinCodeGenService } from './xamarin-codegen.service';
 
@@ -12,6 +13,7 @@ import { XamarinCodeGenService } from './xamarin-codegen.service';
   providers: [
     CodeGenService,
     AngularCodeGenService,
+    AngularElementCodeGenService,
     ReactCodeGenService,
     VueCodeGenService,
     WebComponentCodeGenService,

--- a/src/app/editor/code/editor-container/codegen/codegen.service.ts
+++ b/src/app/editor/code/editor-container/codegen/codegen.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { AngularCodeGenService } from './angular-codegen.service';
+import { AngularElementCodeGenService } from './angular-element-codegen.service';
 import { ReactCodeGenService } from './react-codegen.service';
 import { VueCodeGenService } from './vue-codegen.service';
 import { WebComponentCodeGenService } from './web-component-codegen.service';
@@ -17,6 +18,7 @@ export interface XlayersNgxEditorModel {
   kind:
     | 'png'
     | 'angular'
+    | 'angularElement'
     | 'react'
     | 'vue'
     | 'wc'
@@ -42,6 +44,7 @@ export interface CodeGenFacade {
 export enum CodeGenKind {
   Unknown,
   Angular,
+  AngularElement,
   React,
   Vue,
   WC,
@@ -59,6 +62,7 @@ export class CodeGenService {
 
   constructor(
     private readonly angular: AngularCodeGenService,
+    private readonly angularElement: AngularElementCodeGenService,
     private readonly react: ReactCodeGenService,
     private readonly vue: VueCodeGenService,
     private readonly wc: WebComponentCodeGenService,
@@ -143,6 +147,15 @@ export class CodeGenService {
           content: this.addHeaderInfo(this.angular.generate(this.data)),
           buttons: this.angular.buttons()
         };
+
+      case CodeGenKind.AngularElement:
+        this.trackFrameworkKind(CodeGenKind.AngularElement);
+        return {
+          kind,
+          content: this.addHeaderInfo(this.angularElement.generate(this.data)),
+          buttons: this.angularElement.buttons()
+        };
+
       case CodeGenKind.React:
         this.trackFrameworkKind(CodeGenKind.React);
         return {
@@ -150,6 +163,7 @@ export class CodeGenService {
           content: this.addHeaderInfo(this.react.generate(this.data)),
           buttons: this.react.buttons()
         };
+
       case CodeGenKind.Vue:
         this.trackFrameworkKind(CodeGenKind.Vue);
         return {

--- a/src/app/editor/code/editor-container/editor-container.component.html
+++ b/src/app/editor/code/editor-container/editor-container.component.html
@@ -10,6 +10,14 @@
     </mat-tab>
     <mat-tab>
       <ng-template mat-tab-label>
+        <div class="flex-container" (click)="generateAngularElement()">
+          <mat-icon svgIcon="angularElement"></mat-icon>
+          Angular Element
+        </div>
+      </ng-template>
+    </mat-tab>
+    <mat-tab>
+      <ng-template mat-tab-label>
         <div class="flex-container" (click)="generateVue()">
           <mat-icon svgIcon="vue"></mat-icon>
           Vue

--- a/src/app/editor/code/editor-container/editor-container.component.ts
+++ b/src/app/editor/code/editor-container/editor-container.component.ts
@@ -45,6 +45,11 @@ export class EditorContainerComponent implements OnInit, AfterContentInit {
     this.updateState();
   }
 
+  generateAngularElement() {
+    this.codeSetting = this.codegen.generate(CodeGenKind.AngularElement);
+    this.updateState();
+  }
+
   generateReact() {
     this.codeSetting = this.codegen.generate(CodeGenKind.React);
     this.updateState();

--- a/src/assets/codegen/angularElement.svg
+++ b/src/assets/codegen/angularElement.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 185.6 200">
+    <defs>
+        <style>.cls-1{fill:#448aff;}.cls-2{fill:#2979ff;}.cls-3{fill:#fff;}.cls-4{fill:#a2c5ff;}</style>
+    </defs>
+    <title>components</title>
+    <g id="Layer_2" data-name="Layer 2">
+        <g id="Layer_1-2" data-name="Layer 1">
+            <polygon class="cls-1" points="92.4 0 92.4 0 92.4 0 0 33.3 14 156.1 92.4 200 92.4 200 92.4 200 171.3 156.1 185.6 33.3 92.4 0" />
+            <polygon class="cls-2" points="92.4 0 92.4 22.2 92.4 22.2 92.4 123.2 92.4 123.2 92.4 200 92.4 200 171.3 156.1 185.6 33.3 92.4 0" />
+            <polygon class="cls-3" points="73.6 131.4 54.3 98 84.3 46.1 62.8 46.1 32.8 98 62.8 150 84.4 150 73.6 131.4 73.6 131.4" />
+            <polygon class="cls-4" points="152.8 98 122.8 46.1 84.3 46.1 54.3 98 73.6 64.7 112.1 64.7 131.3 98 112.1 131.4 73.6 131.4 84.4 150 122.8 150 152.8 98" />
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
Add Angular Element code generation support.
The solution tries to streamline the process described in `ngx-build-plus` by Manfred Steyer (https://github.com/manfredsteyer/ngx-build-plus).
If you generate the assets with the editor and follow the README you will create a minimal toolchain to create Angular Elements in general.

Closes #244

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (**codegen**)
- [x] Code style update (formatting, local variables) -> Whitespace in `codegen.service.ts`
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

Issue Number: #244


## What is the new behavior?


## Does this PR introduce a breaking change?



- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

-  [x] add Component codegen
 - [x]  add spec file codegen (if applicable)
 - [x]  add HTML codegen
 - [x]  add styles codegen
 - [x]  add readme codegen
 - [ ]  add export to stackblitz (or other external editor) -> May not make sense because the generation needs manual steps afterwards at the moment.
 - [x]  add unit test -> However it's very basic!
 - [x]  add entry to the editor menu

