### PR TITLE
fix: check if document is null before looking at the symbol

### DIFF
--- a/projects/sketch-lib/src/lib/symbol.service.ts
+++ b/projects/sketch-lib/src/lib/symbol.service.ts
@@ -9,7 +9,7 @@ export class SymbolService {
   }
 
   lookup(current: SketchMSLayer, data: SketchMSData) {
-    const foreignSymbol = data.document.foreignSymbols.find(
+    const foreignSymbol = data.document && data.document.foreignSymbols.find(
       x => x.symbolMaster.symbolID === (current as any).symbolID
     );
 


### PR DESCRIPTION
Need to look closer on what the real problem is but maybe @Shikanime you can shine a lite on this. But document is for some reason null.