### PR TITLE
Remove stencil import from vue aggregator

### DIFF
--- a/libs/vue-codegen/src/lib/vue-aggregator.service.ts
+++ b/libs/vue-codegen/src/lib/vue-aggregator.service.ts
@@ -92,10 +92,7 @@ describe("${className}", () => {
   }
 
   private renderImportStatements(current: SketchMSLayer) {
-    return [
-      "import { Component } from '@stencil/core';",
-      ...this.generateDynamicImport(current),
-    ].join('\n');
+    return [...this.generateDynamicImport(current)].join('\n');
   }
 
   private generateDynamicImport(current: SketchMSLayer) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?

A stencil import is written in the vue.js aggregator.

Issue Number: N/A


## What is the new behavior?

A Vue.js file without stencil import 🙂.

## Does this PR introduce a breaking change?



- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

