### PR TITLE
ci: run steps with dependencies

### DIFF
--- a/.github/workflows/pr_on_development.yml
+++ b/.github/workflows/pr_on_development.yml
@@ -97,7 +97,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.node }}-xlayers-workspace-
       - name: Run lint
-        run: npm run affected:test -- --base=origin/main --head=HEAD --parallel
+        run: npm run affected:test -- --base=origin/main --head=HEAD --parallel --with-deps
   e2e:
     env:
       NX_BRANCH: ${{ github.event.number }}
@@ -128,7 +128,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.node }}-xlayers-workspace-
       - name: Run e2e
-        run: npm run affected:e2e -- --base=origin/main --head=HEAD --parallel
+        run: npm run affected:e2e -- --base=origin/main --head=HEAD --parallel --with-deps
   build:
     env:
       NX_BRANCH: ${{ github.event.number }}
@@ -158,5 +158,5 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.node }}-xlayers-workspace-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.node }}-xlayers-workspace-
-      - name: Run lint
-        run: npm run affected:build -- --base=origin/main --head=HEAD --parallel
+      - name: Run build
+        run: npm run affected:build -- --base=origin/main --head=HEAD --parallel --with-deps


### PR DESCRIPTION
I think the failing CI has to do with a missing flag in NX, `--with deps` should inspect what dependencies should be build before it will start with one of the other librarys.

I believe this will result in succesfull builds for #373 