### PR TITLE
fix: remove core-js libs as they are not needed.

### DIFF
--- a/apps/xlayers/src/app/editor/code/exports/stackblitz/stackblitz.angular.service.ts
+++ b/apps/xlayers/src/app/editor/code/exports/stackblitz/stackblitz.angular.service.ts
@@ -39,8 +39,6 @@ import { XlayersModule } from './xlayers/xlayers.module';
 })
 export class AppModule { }`;
     files['src/main.ts'] = `\
-import 'core-js/es6/reflect';
-import 'core-js/es7/reflect';
 import 'zone.js/dist/zone';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { AppModule } from './app/app.module';


### PR DESCRIPTION
This PR will resolve a problem in Stackblitz where we refer to a core-js part that is not needed by default