### PR TITLE
style: landing fix mobile devices overflow and improve spacing

### DIFF
--- a/apps/xlayers/src/home/interactive-bg/interactive-bg.component.css
+++ b/apps/xlayers/src/home/interactive-bg/interactive-bg.component.css
@@ -4,7 +4,7 @@
 }
 
 section {
-  background-position: 50% 50%;
+  background-position: 50% 0;
   background-repeat: no-repeat;
   background-size: contain;
 }

--- a/apps/xlayers/src/home/interactive-bg/interactive-bg.component.ts
+++ b/apps/xlayers/src/home/interactive-bg/interactive-bg.component.ts
@@ -22,8 +22,13 @@ export class InteractiveBgComponent implements OnInit {
   ngOnInit() {
     this.backgroundImageSrc = {
       'background-image': `url( ${this.src} )`,
-      width: this.width,
-      height: this.height,
+      width: 'calc(100vw - 20px)',
+      height: `calc((100vw - 20px) / (${parseInt(this.width, 0)} / ${parseInt(
+        this.height,
+        0
+      )}))`,
+      'max-width': this.width,
+      'max-height': this.height,
     };
   }
 

--- a/apps/xlayers/src/home/landing/landing.component.css
+++ b/apps/xlayers/src/home/landing/landing.component.css
@@ -5,13 +5,16 @@
 }
 
 header {
-  height: auto;
   display: flex;
   flex-direction: column;
   justify-content: space-evenly;
   align-items: center;
   border-bottom: 1px solid rgba(255, 108, 95, 0.7);
   height: 400px;
+}
+
+header, section {
+  padding: 10px;
 }
 
 header h1 {
@@ -87,8 +90,9 @@ header + svg {
   display: flex;
   flex-direction: row;
   align-items: center;
-  justify-content: center;
   width: 80vw;
+  max-width: 100%;
+  flex-wrap: wrap;
   justify-content: space-evenly;
 }
 
@@ -175,7 +179,7 @@ footer i {
 
 .bg img {
   width: 600px;
-  max-width: 100%;
+  max-width: calc(100vw - 20px);
 }
 
 .bg.interactive {
@@ -185,6 +189,10 @@ footer i {
 
 .bg.interactive img {
   width: 1392px;
+}
+
+.bg.interactive h1:not(:first-of-type) {
+  padding: 60px 0 0;
 }
 
 .bg p {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests locally manually

## PR Type

Improve style of the landing, notably fix an overflow issue on mobile devices.

- [X] Other: style


## What is the current behavior?
Overflow on mobile devices and two-three small other spacing issues.

See Screenshots before vs after.


## Does this PR introduce a breaking change?

- [X] No


## Other information

Padding:

<img width="320" alt="padding_before" src="https://user-images.githubusercontent.com/16886711/112187235-3744a180-8c02-11eb-9d00-59113f154792.png">
<img width="320" alt="padding_after" src="https://user-images.githubusercontent.com/16886711/112187253-3ad82880-8c02-11eb-8fbc-af2eeef113f0.png">

Spacing:
<img width="320" alt="spacing_before" src="https://user-images.githubusercontent.com/16886711/112187290-4297cd00-8c02-11eb-81a3-07daf78e33de.png">
<img width="320" alt="spacing_after" src="https://user-images.githubusercontent.com/16886711/112187305-44fa2700-8c02-11eb-9c04-a34933e6e308.png">

Overflow:
<img width="320" alt="overflow_before" src="https://user-images.githubusercontent.com/16886711/112187322-49bedb00-8c02-11eb-9cc9-8ee33532ec7e.png">
<img width="320" alt="overflow_after" src="https://user-images.githubusercontent.com/16886711/112187336-4c213500-8c02-11eb-8439-6da8e2ebc0f4.png">

Images:
<img width="320" alt="images_before" src="https://user-images.githubusercontent.com/16886711/112187347-504d5280-8c02-11eb-8686-6b08308abb5b.png">
<img width="320" alt="images_after" src="https://user-images.githubusercontent.com/16886711/112187359-52afac80-8c02-11eb-817b-2248db090b16.png">

