### PR TITLE
style: landing redo background position

### DIFF
--- a/apps/xlayers/src/home/interactive-bg/interactive-bg.component.css
+++ b/apps/xlayers/src/home/interactive-bg/interactive-bg.component.css
@@ -4,7 +4,7 @@
 }
 
 section {
-  background-position: 50% 0;
+  background-position: 50% 50%;
   background-repeat: no-repeat;
   background-size: contain;
 }

--- a/apps/xlayers/src/home/interactive-bg/interactive-bg.component.css
+++ b/apps/xlayers/src/home/interactive-bg/interactive-bg.component.css
@@ -116,6 +116,12 @@ section {
   animation-iteration-count: infinite;
 }
 
+@media (max-width: 1060px) {
+  .xly-btn--pulse {
+    display: none;
+  }
+}
+
 @keyframes pulsate {
   0% {
     opacity: 0;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Test locally


## PR Type

- [X] Style



## What is the current behavior?
In my previous PR #413 I modified the background positioning of `interactive-bg` to improve the spacing. This has for side effect to display the "clickable pink dot" a bit of.

This PR revert the positioning of the background image to align click events and images.

In addition, as discussed in previous PR, it hides the "pulse" button if the screen is not wide enough (I picked 1060px).

Being said, doing so it looses the improvements of the spacing. Maybe something to improve one of these days.

P.S.: Sorry did not noticed these pink dots were clickable and dynamic, would have not modify the property in first place if I would have noticed it...

## Screenshots
<img width="320" alt="Capture d’écran 2021-03-23 à 18 47 49" src="https://user-images.githubusercontent.com/16886711/112193629-5e05d680-8c08-11eb-9a85-86df11204dc6.png">


