### PR TITLE
fix(export): README.md file is exported in the wrong directory in stackblitz

### DIFF
--- a/apps/xlayers/src/app/editor/code/exports/stackblitz/stackblitz.angular.service.ts
+++ b/apps/xlayers/src/app/editor/code/exports/stackblitz/stackblitz.angular.service.ts
@@ -13,6 +13,8 @@ export class ExportStackblitzAngularService {
         if (prop === 'uri') {
           if (content[i].language === 'base64') {
             files[`src/app/` + content[i].uri] = content[i].value;
+          } else if (content[i].language === 'markdown') {
+            files[content[i].uri] = content[i].value;
           } else {
             files[`src/app/xlayers/` + content[i].uri] = content[i].value;
           }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature (please, look at the "Scope of the project" section in the README.md file)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
READMD.md being exported in the wrong directory

Issue Number: #432


## What is the new behavior?
READMD.md file is now exported to the root directory of project

## Does this PR introduce a breaking change?



- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Closes #432 